### PR TITLE
Work-around broken 'restart' in init script

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'vir.khatri@gmail.com'
 license 'Apache-2.0'
 description 'Installs/Configures Elastic Auditbeat'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.0.3'
+version '0.0.4'
 source_url 'https://github.com/vkhatri/chef-auditbeat' if respond_to?(:source_url)
 issues_url 'https://github.com/vkhatri/chef-auditbeat/issues' if respond_to?(:issues_url)
 chef_version '>= 12' if respond_to?(:chef_version)

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -17,6 +17,6 @@ service node['auditbeat']['service']['name'] do
   provider Chef::Provider::Service::Solaris if node['platform_family'] == 'solaris2'
   retries node['auditbeat']['service']['retries']
   retry_delay node['auditbeat']['service']['retry_delay']
-  supports :status => true, :restart => true
+  supports :status => true, :restart => !centos6?, :reload => false
   action service_action
 end


### PR DESCRIPTION
The [Auditbeat init script](https://github.com/elastic/beats/blob/master/dev-tools/packaging/templates/rpm/init.sh.tmpl#L79) does a `test config` in `restart` before doing the `stop`/`start`, and this causes the `restart` to fail, because `test config` can hang ([possibly related](https://github.com/elastic/beats/issues/16046)) if there's already a running Auditbeat process. We can work around this by forcing Chef to do an explicit `stop`/`start` in CentOS 6.
